### PR TITLE
Fix script issues and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,12 @@ Noir Core Utility Scripts is a collection of lightweight Windows batch scripts d
 ## Features
 
 - **adm**: Elevates privileges to allow administrative tasks.
+- **doskey.mac**: Doskey macros for common shortcuts (`cc` copies current directory, `q` exits).
 - **env**: Opens the Windows Environment Variables in Administrative mode.
-- **h**: Puts your system into hibernation.
+- **h**: Puts your system to sleep.
+- **hash**: Computes the file hash and copies it to the clipboard.
+- **hosts**: Opens the Windows hosts file in Notepad with administrative privileges.
+- **mk**: Creates a directory and immediately changes into it.
 - **restart**: Safely restarts Windows Explorer by stopping it, waiting for input, and then restoring it.
 
 ## Installation

--- a/adm.cmd
+++ b/adm.cmd
@@ -8,7 +8,7 @@ shift
 set "args="
 :buildArgs
 if "%1"=="" goto doneArgs
-set "args=%args% %1
+set "args=%args% %1"
 shift
 goto buildArgs
 :doneArgs

--- a/env.cmd
+++ b/env.cmd
@@ -1,3 +1,3 @@
 @echo off
-call adm %0
+call adm %~f0
 start rundll32 sysdm.cpl,EditEnvironmentVariables

--- a/h.cmd
+++ b/h.cmd
@@ -1,1 +1,2 @@
+@echo off
 rundll32.exe powrprof.dll, SetSuspendState Sleep

--- a/hash.cmd
+++ b/hash.cmd
@@ -1,2 +1,2 @@
 @echo off
-powershell -command (Get-FileHash %*).hash | clip
+powershell -command "(Get-FileHash '%~1').hash | clip"

--- a/hosts.cmd
+++ b/hosts.cmd
@@ -1,3 +1,3 @@
 @echo off
-call adm %0
+call adm %~f0
 notepad C:\Windows\System32\drivers\etc\hosts

--- a/mk.cmd
+++ b/mk.cmd
@@ -1,2 +1,2 @@
 @echo off
-md %1 & cd %1
+md "%~1" & cd "%~1"


### PR DESCRIPTION
This PR addresses several bugs and inconsistencies found in the core utility scripts:

## Bug Fixes
- **adm.cmd**: Fixed missing closing quote in args assignment that could cause silent failures
- **env.cmd / hosts.cmd**: Changed %0 to %~f0 for reliable script path resolution during elevation
- **hash.cmd**: Quoted file path to handle paths with spaces
- **mk.cmd**: Quoted directory name to handle names with spaces

## Improvements
- **h.cmd**: Added @echo off for consistency with other scripts

## Documentation
- **README.md**: Corrected h.cmd description (sleep, not hibernation) and added missing documentation for doskey.mac, hash, hosts, and mk scripts